### PR TITLE
Fix segmentation duplicates and clean imports

### DIFF
--- a/calcium_analysis/analysis.py
+++ b/calcium_analysis/analysis.py
@@ -1,4 +1,3 @@
-import os
 from .image_processing import image_to_stack
 from .data_extraction import roi_to_data
 from .image_segmentation import stack_to_roi

--- a/calcium_analysis/image_processing.py
+++ b/calcium_analysis/image_processing.py
@@ -5,6 +5,7 @@ from PIL.TiffTags import TAGS
 import numpy as np
 import os
 import xml.etree.ElementTree as ET
+from typing import Tuple, Dict, Any
 
 def load_image(image_path: str) -> Tuple[np.ndarray, Dict[str, Any]]:
     """

--- a/calcium_analysis/image_segmentation.py
+++ b/calcium_analysis/image_segmentation.py
@@ -3,11 +3,6 @@ from skimage import filters, measure, segmentation, feature, io
 from scipy import ndimage as ndi
 from typing import Tuple
 
-import numpy as np
-from skimage import filters, measure, segmentation, feature, io
-from scipy import ndimage as ndi
-from typing import Tuple
-
 def stack_to_roi(image_path: str, sd: float) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Perform image segmentation on an image stack.
@@ -23,29 +18,6 @@ def stack_to_roi(image_path: str, sd: float) -> Tuple[np.ndarray, np.ndarray, np
     Returns:
     Tuple[np.ndarray, np.ndarray, np.ndarray]: A tuple containing the labeled image, the mean image, and the binary image after morphological opening.
     """
-
-    # Load the image stack
-    I_t = np.load(image_path)
-
-    # Compute the mean image
-    I_mean = np.mean(I_t, axis=2)
-
-    # Perform thresholding
-    I_bw1 = I_mean > filters.threshold_local(I_mean, block_size=15)
-
-    # Perform morphological opening
-    I_bw2 = ndi.binary_opening(I_bw1, structure=np.ones((3, 3)))
-
-    # Identify connected components
-    labels = measure.label(I_bw2)
-
-    # Save the results
-    np.save('I_mean.npy', I_mean)
-    np.save('I_bw2.npy', I_bw2)
-    np.save('labels.npy', labels)
-
-    # Return the results
-    return labels, I_mean, I_bw2
 
     # Load the image stack
     I_t = np.load(image_path)


### PR DESCRIPTION
## Summary
- remove duplicated imports and duplicated code from `image_segmentation`
- drop unused `os` import from `analysis`
- add missing typing imports to `image_processing`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dffb299148332a8a79f51209d7e68