### PR TITLE
Add pre-commit config and integrate into CI

### DIFF
--- a/.github/workflows/test_workflow.yml
+++ b/.github/workflows/test_workflow.yml
@@ -19,6 +19,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r calcium_analysis/requirements.txt
+        pip install pre-commit
+
+    - name: Run pre-commit
+      run: pre-commit run --all-files --show-diff-on-failure
 
     - name: Run tests
       run: pytest tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 23.7.0
+  hooks:
+    - id: black
+      args: [--line-length=79]
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+      args: [--profile=black]
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.0.287
+  hooks:
+    - id: ruff

--- a/README.md
+++ b/README.md
@@ -44,3 +44,18 @@ Where:
 - `--image_fld` is the path to the image folder.
 - `--save_fld` is the path to the save folder.
 - `--sd` is the standard deviation value.
+## Pre-commit hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run `black`, `isort`, and `ruff` on your changes.
+Install pre-commit and set up the git hooks with:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+You can check all files at any time by running:
+
+```bash
+pre-commit run --all-files
+```


### PR DESCRIPTION
## Summary
- add a `.pre-commit-config.yaml` with black, isort and ruff
- document how to use pre-commit in `README.md`
- run pre-commit in GitHub Actions before running tests

## Testing
- `pre-commit run --files README.md .github/workflows/test_workflow.yml .pre-commit-config.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e00c0807c83329578c97c4f89e2ba